### PR TITLE
Run GitHub Actions against multiple Rubies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  specs:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,16 +12,32 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
-        ruby:
-          - 3.0.3
+        ruby-version:
+          - head
+          - '3.2'
+          - '3.1'
+          - '3.0'
+          - jruby
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+    - name: Run tests
+      run: bundle exec rake spec
+  rubocop:
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}
+        ruby-version: '3.0'
         bundler-cache: true
-    - name: Run the default task
-      run: bundle exec rake
+    - name: Run RuboCop
+      run: bundle exec rake rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
       httparty (>= 0.18.1)
     ruby-progressbar (1.11.0)
     sqlite3 (1.6.0-x86_64-darwin)
+    sqlite3 (1.6.0-x86_64-linux)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
@@ -100,6 +101,8 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   activerecord (~> 7.0)
@@ -116,4 +119,4 @@ DEPENDENCIES
   webmock (~> 3.18.1)
 
 BUNDLED WITH
-   2.2.32
+   2.4.7


### PR DESCRIPTION
This PR updates GitHub actions so they run specs against multiple Rubies (3.0, 3.1, 3.2, head, and JRuby).  The config file is updated so that Rubocop runs only once (against 3.0) and in parallel.

To get Rubocop running on GitHub actions I needed to add the Linux platform to the Gemfile.lock.  And to get it running on my laptop I needed to add a more recent darwin.  At the same time I updated the bundler version.  As this is a gem and not an app, it may be desirable to exclude the Gemfile.lock from GitHub and allow local environments to rebuild it.