### PR TITLE
Get GitHub Actions to green

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - head
           - '3.2'
           - '3.1'
           - '3.0'
-          - jruby
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,11 +39,23 @@ jobs:
       with:
         ruby-version: '3.0'
         bundler-cache: true
-    - name: name: Run RuboCop
+    - name: Run RuboCop
       run: bundle exec rake rubocop
 
+  publish-rubygem:
+    runs-on: ubuntu-latest
+    name: Publish Ruby Gem
+    needs: [specs, rubocop]
+
+    steps:
     - name: publish gem
-      run: |
+      uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.0'
+        bundler-cache: true
+    - run: |
         mkdir -p $HOME/.gem
         touch $HOME/.gem/credentials
         chmod 0600 $HOME/.gem/credentials

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,18 +30,11 @@ RSpec.configure do |c|
   c.expect_with :rspec do |rspec|
     rspec.syntax = :expect
   end
+
+  c.before do
+    allow(ENV).to receive(:fetch).with("OPENAI_ACCESS_TOKEN", nil).and_return("abcdef") unless ENV["OPENAI_ACCESS_TOKEN"]
+    allow(ENV).to receive(:fetch).with("SERPAPI_API_KEY", nil).and_return("abcdef") unless ENV["SERPAPI_API_KEY"]
+  end
 end
 
 RSPEC_ROOT = File.dirname __FILE__
-
-# RSpec.configure do |config|
-#   # Enable flags like --only-failures and --next-failure
-#   config.example_status_persistence_file_path = ".rspec_status"
-
-#   # Disable RSpec exposing methods globally on `Module` and `main`
-#   config.disable_monkey_patching!
-
-#   config.expect_with :rspec do |c|
-#     c.syntax = :expect
-#   end
-# end


### PR DESCRIPTION
This is built on top of #3 (to address the config typo) and implements the second option described in #4 

I also removed head and jruby from the CI matrix, because they are having trouble running with a single `Gemfile.lock`.  If `Gemfile.lock` is removed from the repo they can be readded.

Runs green on my fork.