### PR TITLE
rename class Serp to GoogleSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Or install it yourself as:
 
 ## Usage
 
-We will be adding more examples soon, but here are a couple to get you started. First, you'll need to set up your environment variables for OpenAI and Serp (OPENAI_ACCESS_TOKEN, SERPAPI_API_KEY). If you prefer not to set these variables in your environment, you can pass them directly into the API.
+We will be adding more examples soon, but here are a couple to get you started. First, you'll need to set up your environment variables for OpenAI and Google SERP (OPENAI_ACCESS_TOKEN, SERPAPI_API_KEY). If you prefer not to set these variables in your environment, you can pass them directly into the API.
 
 In the examples below, we added one rubygem to load the environment at the first line, but depending on what you want, you might not need this.
 ```ruby

--- a/lib/boxcars/boxcar.rb
+++ b/lib/boxcars/boxcar.rb
@@ -116,5 +116,5 @@ end
 
 require "boxcars/boxcar/engine_boxcar"
 require "boxcars/boxcar/calculator"
-require "boxcars/boxcar/serp"
+require "boxcars/boxcar/google_search"
 require "boxcars/boxcar/sql"

--- a/lib/boxcars/boxcar/google_search.rb
+++ b/lib/boxcars/boxcar/google_search.rb
@@ -2,8 +2,9 @@
 
 require 'google_search_results'
 module Boxcars
-  # A Boxcar that uses the Google SerpAPI to get answers to questions.
-  class Serp < Boxcar
+  # A Boxcar that uses the Google SERP API to get answers to questions.
+  # It looks through SERP (search engine results page) results to find the answer.
+  class GoogleSearch < Boxcar
     # the description of this boxcar
     SERPDESC = "useful for when you need to answer questions about current events." \
                "You should ask targeted questions"
@@ -15,14 +16,14 @@ module Boxcars
     def initialize(name: "Search", description: SERPDESC, serpapi_api_key: "not set")
       super(name: name, description: description)
       api_key = Boxcars.configuration.serpapi_api_key(serpapi_api_key: serpapi_api_key)
-      GoogleSearch.api_key = api_key
+      ::GoogleSearch.api_key = api_key
     end
 
     # Get an answer from Google using the SerpAPI.
     # @param question [String] The question to ask Google.
     # @return [String] The answer to the question.
     def run(question)
-      search = GoogleSearch.new(q: question)
+      search = ::GoogleSearch.new(q: question)
       rv = find_answer(search.get_hash)
       puts "Question: #{question}"
       puts "Answer: #{rv}"
@@ -33,7 +34,7 @@ module Boxcars
     # @param question [String] The question to ask Google.
     # @return [String] The location found.
     def get_location(question)
-      search = GoogleSearch.new(q: question, limit: 3)
+      search = ::GoogleSearch.new(q: question, limit: 3)
       rv = search.get_location
       puts "Question: #{question}"
       puts "Answer: #{rv}"

--- a/notebooks/boxcars_examples.ipynb
+++ b/notebooks/boxcars_examples.ipynb
@@ -55,11 +55,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "cc4ee1c4-705a-4c24-a42d-d821766be078",
    "metadata": {},
    "source": [
-    "### Search using the Serp API (set SERPAPI_API_KEY in .env)"
+    "### Search using the Google Serp API (set SERPAPI_API_KEY in .env)"
    ]
   },
   {
@@ -88,8 +89,8 @@
     }
    ],
    "source": [
-    "# showcase Serp search\n",
-    "s = Boxcars::Serp.new\n",
+    "# showcase Google search\n",
+    "s = Boxcars::GoogleSearch.new\n",
     "s.run(\"what temperature is it in Phoenix?\")"
    ]
   },

--- a/spec/boxcars/google_search_spec.rb
+++ b/spec/boxcars/google_search_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Boxcars::Serp do
+RSpec.describe Boxcars::GoogleSearch do
   context "without a serpapi api key" do
     it "raises an error" do
       expect do

--- a/spec/boxcars/train_spec.rb
+++ b/spec/boxcars/train_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Boxcars::Train do
-  let(:search) { Boxcars::Serp.new }
+  let(:search) { Boxcars::GoogleSearch.new }
   let(:calculator) { Boxcars::Calculator.new }
   let(:train) { Boxcars.default_train.new(boxcars: [search, calculator]) }
 

--- a/spec/boxcars/zero_shot_spec.rb
+++ b/spec/boxcars/zero_shot_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Boxcars::ZeroShot do
   let(:engine) { Boxcars::Openai.new }
-  let(:search) { Boxcars::Serp.new }
+  let(:search) { Boxcars::GoogleSearch.new }
   let(:calculator) { Boxcars::Calculator.new(engine: engine) }
   let(:train) { described_class.new(engine: engine, boxcars: [search, calculator]) }
 


### PR DESCRIPTION
GoogleSearch class name seems better than just Serp.