### PR TITLE
use structured results internally and bring SQL up to parity with ActiveRecord boxcar.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    boxcars (0.2.0)
+    boxcars (0.2.1)
       google_search_results (~> 2.2)
       ruby-openai (~> 3.0)
 

--- a/lib/boxcars/boxcar/calculator.rb
+++ b/lib/boxcars/boxcar/calculator.rb
@@ -13,11 +13,9 @@ module Boxcars
     def initialize(engine: nil, prompt: nil, **kwargs)
       the_prompt = prompt || my_prompt
       kwargs[:stop] ||= ["```output"]
-      super(name: kwargs[:name] || "Calculator",
-            description: kwargs[:description] || CALCDESC,
-            engine: engine,
-            prompt: the_prompt,
-            **kwargs)
+      kwargs[:name] ||= "Calculator"
+      kwargs[:description] ||= CALCDESC
+      super(engine: engine, prompt: the_prompt, **kwargs)
     end
 
     private
@@ -25,7 +23,7 @@ module Boxcars
     def get_embedded_ruby_answer(text)
       code = text[8..-4].split("```").first.strip
       ruby_executor = Boxcars::RubyREPL.new
-      ruby_executor.call(code: code).strip
+      ruby_executor.call(code: code)
     end
 
     def get_answer(text)
@@ -33,9 +31,9 @@ module Boxcars
       when /^```ruby/
         get_embedded_ruby_answer(text)
       when /^Answer:/
-        text
+        Result.from_text(text)
       else
-        raise Boxcars::Error "Unknown format from engine: #{text}"
+        Result.new(status: :error, explanation: "Unknown format from engine: #{text}")
       end
     end
 

--- a/lib/boxcars/boxcar/engine_boxcar.rb
+++ b/lib/boxcars/boxcar/engine_boxcar.rb
@@ -16,7 +16,7 @@ module Boxcars
       @engine = engine || Boxcars.engine.new
       @top_k = kwargs[:top_k] || 5
       @stop = kwargs[:stop] || ["Answer:"]
-      super(name: name, description: description)
+      super(name: name, description: description, return_direct: kwargs[:return_direct])
     end
 
     # input keys for the prompt
@@ -95,7 +95,7 @@ module Boxcars
     def check_output_keys
       return unless output_keys.length != 1
 
-      raise Boxcars::ArgumentError, "run not supported when there is not exactly one output key. Got #{output_keys}."
+      raise Boxcars::ArgumentError, "not supported when there is not exactly one output key. Got #{output_keys}."
     end
 
     # call the boxcar
@@ -104,7 +104,7 @@ module Boxcars
     def call(inputs:)
       t = predict(**prediction_variables(inputs)).strip
       answer = get_answer(t)
-      Boxcars.debug answer, :magenta
+      Boxcars.debug answer.to_json, :magenta
       { output_keys.first => answer }
     end
 

--- a/lib/boxcars/result.rb
+++ b/lib/boxcars/result.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Boxcars
+  # used by Boxcars to return structured result and additional context
+  class Result
+    attr_reader :status, :answer, :explanation, :suggestions, :added_context
+
+    # @param status [Symbol] :ok or :error
+    # @param answer [String] The answer to the question
+    # @param explanation [String] The explanation of the answer
+    # @param suggestions [Array<String>] The next suggestions for the user
+    # @param added_context [Hash] Any additional context to add to the result
+    def initialize(status:, answer: nil, explanation: nil, suggestions: nil, **added_context)
+      @status = status
+      @answer = answer || explanation
+      @explanation = explanation
+      @suggestions = suggestions
+      @added_context = added_context
+    end
+
+    # @return [Hash] The result as a hash
+    def to_h
+      {
+        status: status,
+        answer: answer,
+        explanation: explanation,
+        suggestions: suggestions
+      }.merge(added_context).compact
+    end
+
+    # @return [String] The result as a json string
+    def to_json(*args)
+      JSON.generate(to_h, *args)
+    end
+
+    # @return [String] An explanation of the result
+    def to_s
+      explanation
+    end
+
+    # @return [String] The answer data to the question
+    def to_answer
+      answer
+    end
+
+    # create a new Result from a text string
+    # @param text [String] The text to use for the result
+    # @param kwargs [Hash] Any additional kwargs to pass to the result
+    # @return [Boxcars::Result] The result
+    def self.from_text(text, **kwargs)
+      answer = text.delete_prefix('"').delete_suffix('"').strip
+      answer = Regexp.last_match(:answer) if answer =~ /^Answer:\s*(?<answer>.*)$/
+      explanation = "Answer: #{answer}"
+      new(status: :ok, answer: answer, explanation: explanation, **kwargs)
+    end
+
+    # create a new Result from an error string
+    # @param error [String] The error to use for the result
+    # @param kwargs [Hash] Any additional kwargs to pass to the result
+    # @return [Boxcars::Result] The error result
+    def self.from_error(error, **kwargs)
+      answer = error
+      answer = Regexp.last_match(:answer) if answer =~ /^Error:\s*(?<answer>.*)$/
+      explanation = "Error: #{answer}"
+      new(status: :error, answer: answer, explanation: explanation, **kwargs)
+    end
+  end
+end

--- a/lib/boxcars/ruby_repl.rb
+++ b/lib/boxcars/ruby_repl.rb
@@ -9,19 +9,20 @@ module Boxcars
       Boxcars.debug "RubyREPL: #{code}", :yellow
 
       # wrap the code in an excption block so we can catch errors
-      code = "begin\n#{code}\nrescue Exception => e\n  puts 'Error: ' + e.message\nend"
+      wrapped = "begin\n#{code}\nrescue Exception => e\n  puts 'Error: ' + e.message\nend"
       output = ""
       IO.popen("ruby", "r+") do |io|
-        io.puts code
+        io.puts wrapped
         io.close_write
         output = io.read
       end
       if output =~ /^Error: /
-        Boxcars.error output
-        output
+        Boxcars.debug output, :red
+        Result.from_error(output, code: code)
+      else
+        Boxcars.debug "Answer: #{output}", :yellow, style: :bold
+        Result.from_text(output, code: code)
       end
-      Boxcars.debug "Answer: #{output}", :yellow, style: :bold
-      output
     end
 
     # Execute ruby code

--- a/lib/boxcars/train.rb
+++ b/lib/boxcars/train.rb
@@ -51,13 +51,16 @@ module Boxcars
       full_output = predict(**full_inputs)
       parsed_output = extract_boxcar_and_input(full_output)
       while parsed_output.nil?
-        full_output = _fix_text(full_output)
         full_inputs[:agent_scratchpad] += full_output
         output = predict(**full_inputs)
         full_output += output
         parsed_output = extract_boxcar_and_input(full_output)
       end
-      TrainAction.new(boxcar: parsed_output[0], boxcar_input: parsed_output[1], log: full_output)
+      if parsed_output.is_a?(Result)
+        TrainAction.from_result(boxcar: "Final Answer", result: parsed_output, log: full_output)
+      else
+        TrainAction.new(boxcar: parsed_output[0], boxcar_input: parsed_output[1], log: full_output)
+      end
     end
 
     # Given input, decided what to do.

--- a/lib/boxcars/train/train_action.rb
+++ b/lib/boxcars/train/train_action.rb
@@ -5,10 +5,24 @@ module Boxcars
   class TrainAction
     attr_accessor :boxcar, :boxcar_input, :log
 
-    def initialize(boxcar: nil, boxcar_input: nil, log: nil)
-      @boxcar = boxcar
+    # record for a train action
+    # @param boxcar [String] The boxcar to run.
+    # @param log [String] The log of the action.
+    # @param boxcar_input [String] The input to the boxcar.
+    # @return [Boxcars::TrainAction] The train action.
+    def initialize(boxcar:, log:, boxcar_input: nil)
       @boxcar_input = boxcar_input
+      @boxcar = boxcar
       @log = log
+    end
+
+    # build a train action from a result
+    # @param result [Boxcars::Result] The result to build from.
+    # @param boxcar [String] The boxcar to run.
+    # @param log [String] The log of the action.
+    # @return [Boxcars::TrainAction] The train action.
+    def self.from_result(result:, boxcar:, log:)
+      new(boxcar: boxcar, boxcar_input: result.to_answer, log: log)
     end
   end
 end

--- a/lib/boxcars/train/zero_shot.rb
+++ b/lib/boxcars/train/zero_shot.rb
@@ -69,7 +69,8 @@ module Boxcars
       #   with "Action Input:" should be separated by a newline.
       if engine_output.include?(FINAL_ANSWER_ACTION)
         answer = engine_output.split(FINAL_ANSWER_ACTION).last.strip
-        ['Final Answer', answer]
+        Result.new(status: :ok, answer: answer, explanation: engine_output)
+        # ['Final Answer', answer]
       else
         # the thought should be the frist line here if it doesn't start with "Action:"
         thought = engine_output.split(/\n+/).reject(&:empty?).first

--- a/lib/boxcars/version.rb
+++ b/lib/boxcars/version.rb
@@ -2,5 +2,5 @@
 
 module Boxcars
   # The current version of the gem.
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/boxcars/calculator_spec.rb
+++ b/spec/boxcars/calculator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Boxcars::Calculator do
       engine = Boxcars::Openai.new
       VCR.use_cassette("calculator") do
         expect(described_class.new(engine: engine)
-          .run("what is 2.173 to the power of 22.1 then diveded by 27.2? Round to 5 digits.")).to eq("1033834.56373")
+          .run("what is 2.173 to the power of 22.1 then diveded by 27.2 to 5 significant digits?")).to eq("1033834.56373")
       end
     end
   end

--- a/spec/boxcars/ruby_repl_spec.rb
+++ b/spec/boxcars/ruby_repl_spec.rb
@@ -4,15 +4,15 @@ RSpec.describe Boxcars::RubyREPL do
   context "with RubyREPL" do
     repl = described_class.new
     it "prints" do
-      expect(repl.run("puts 'hello'")).to eq("hello\n")
+      expect(repl.run("puts 'hello'").to_answer).to eq("hello")
     end
 
     it "does math easy math" do
-      expect(repl.run("puts 2 + 2")).to eq("4\n")
+      expect(repl.run("puts 2 + 2").to_answer).to eq("4")
     end
 
     it "does math hard math" do
-      expect(repl.run("puts Math.sqrt(16)")).to eq("4.0\n")
+      expect(repl.run("puts Math.sqrt(16)").to_answer).to eq("4.0")
     end
   end
 end

--- a/spec/boxcars/sql_spec.rb
+++ b/spec/boxcars/sql_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe Boxcars::SQL do
 
     it "can count comments from john" do
       VCR.use_cassette("sql") do
-        expect(boxcar.run("how many comments are there from John?")).to include(":2")
+        expect(boxcar.run("how many comments are there from John?")).to be(2)
       end
     end
 
     it "can find the last comment to the first post" do
       VCR.use_cassette("sql2") do
-        expect(boxcar.run("What is the last comment for the first post?")).to include(" johns second ")
+        expect(boxcar.run("What is the last comment for the first post?").to_s).to include(" johns second ")
       end
     end
   end

--- a/spec/fixtures/cassettes/ar1.yml
+++ b/spec/fixtures/cassettes/ar1.yml
@@ -111,11 +111,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Mar 2023 20:42:02 GMT
+      - Wed, 08 Mar 2023 14:51:10 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '357'
+      - '361'
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -127,18 +127,18 @@ http_interactions:
       Openai-Organization:
       - user-ri9zw9ahumb1bo9vs73mudbi
       Openai-Processing-Ms:
-      - '913'
+      - '990'
       Openai-Version:
       - '2020-10-01'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       X-Request-Id:
-      - a49b649fa97fa800873d9a2c79b84c46
+      - bddb4094f526396738162edbfac1c8c8
     body:
       encoding: UTF-8
-      string: '{"id":"chatcmpl-6rBwfFL0SoUVcVxRlTpwjIMh0kEDf","object":"chat.completion","created":1678135321,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":295,"completion_tokens":21,"total_tokens":316},"choices":[{"message":{"role":"assistant","content":"\n\nARCode:
-        Comment.joins(:user).where(users: {name: ''John''}).count\n"},"finish_reason":"stop","index":0}]}
+      string: '{"id":"chatcmpl-6rpQDpEu3VO8epiOz8yWHTFpNyUy1","object":"chat.completion","created":1678287069,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":295,"completion_tokens":22,"total_tokens":317},"choices":[{"message":{"role":"assistant","content":"\n\nARCode:
+        Comment.joins(:user).where(users: { name: \"John\" }).count\n"},"finish_reason":"stop","index":0}]}
 
         '
-  recorded_at: Mon, 06 Mar 2023 20:42:02 GMT
+  recorded_at: Wed, 08 Mar 2023 14:51:10 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/ar2.yml
+++ b/spec/fixtures/cassettes/ar2.yml
@@ -111,7 +111,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Mar 2023 20:42:06 GMT
+      - Wed, 08 Mar 2023 14:51:11 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -127,18 +127,18 @@ http_interactions:
       Openai-Organization:
       - user-ri9zw9ahumb1bo9vs73mudbi
       Openai-Processing-Ms:
-      - '1089'
+      - '1054'
       Openai-Version:
       - '2020-10-01'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       X-Request-Id:
-      - 714fefada56b8846a513c14c059812ac
+      - 118603cce8d3f7d4470cc0647fa218dc
     body:
       encoding: UTF-8
-      string: '{"id":"chatcmpl-6rBwjo5mZD24nCQhChRepVVWa7ugG","object":"chat.completion","created":1678135325,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":299,"completion_tokens":16,"total_tokens":315},"choices":[{"message":{"role":"assistant","content":"\n\nARCode:
+      string: '{"id":"chatcmpl-6rpQEuBuD4NsscrmCg2Yiqvv0W6fW","object":"chat.completion","created":1678287070,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":299,"completion_tokens":16,"total_tokens":315},"choices":[{"message":{"role":"assistant","content":"\n\nARCode:
         Comment.where(ticket_id: Ticket.first.id).last.content\n"},"finish_reason":null,"index":0}]}
 
         '
-  recorded_at: Mon, 06 Mar 2023 20:42:06 GMT
+  recorded_at: Wed, 08 Mar 2023 14:51:11 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/ar3.yml
+++ b/spec/fixtures/cassettes/ar3.yml
@@ -111,11 +111,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Mar 2023 20:42:10 GMT
+      - Wed, 08 Mar 2023 14:51:13 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '376'
+      - '359'
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -127,18 +127,18 @@ http_interactions:
       Openai-Organization:
       - user-ri9zw9ahumb1bo9vs73mudbi
       Openai-Processing-Ms:
-      - '1174'
+      - '1048'
       Openai-Version:
       - '2020-10-01'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       X-Request-Id:
-      - 666c9d70dc770bd14ea7371c2ad0e60e
+      - c78dee57f95bde0d99df6c66f93cade7
     body:
       encoding: UTF-8
-      string: '{"id":"chatcmpl-6rBwn7LXw9cz24HwLxZY9k4GdzMZF","object":"chat.completion","created":1678135329,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":292,"completion_tokens":27,"total_tokens":319},"choices":[{"message":{"role":"assistant","content":"\n\nARCode:
-        Comment.joins(:user).where(users: {name: \"John\"}).count\nARChanges: None\n"},"finish_reason":"stop","index":0}]}
+      string: '{"id":"chatcmpl-6rpQGqZ6KycvNuW2H5TDqgGuhePn1","object":"chat.completion","created":1678287072,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":292,"completion_tokens":22,"total_tokens":314},"choices":[{"message":{"role":"assistant","content":"\n\nARCode:
+        Comment.joins(:user).where(users: {name: \"John\"}).count\n"},"finish_reason":"stop","index":0}]}
 
         '
-  recorded_at: Mon, 06 Mar 2023 20:42:10 GMT
+  recorded_at: Wed, 08 Mar 2023 14:51:13 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/ar4.yml
+++ b/spec/fixtures/cassettes/ar4.yml
@@ -111,11 +111,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Mar 2023 20:42:15 GMT
+      - Wed, 08 Mar 2023 14:51:14 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '342'
+      - '356'
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -127,18 +127,18 @@ http_interactions:
       Openai-Organization:
       - user-ri9zw9ahumb1bo9vs73mudbi
       Openai-Processing-Ms:
-      - '2309'
+      - '779'
       Openai-Version:
       - '2020-10-01'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       X-Request-Id:
-      - 93114a62df1a18fbb1ef49c49fa88673
+      - cc8c15bfd64e125a0fff19b73f1ff028
     body:
       encoding: UTF-8
-      string: '{"id":"chatcmpl-6rBwrPDdwWOAWqCpi8z5oPbwNAo6W","object":"chat.completion","created":1678135333,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":299,"completion_tokens":15,"total_tokens":314},"choices":[{"message":{"role":"assistant","content":"\n\nARCode:
-        Comment.where(ticket_id: 1).last.content\n"},"finish_reason":"stop","index":0}]}
+      string: '{"id":"chatcmpl-6rpQHG0BZVO4uV9OOus1yIZxNCcie","object":"chat.completion","created":1678287073,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":299,"completion_tokens":16,"total_tokens":315},"choices":[{"message":{"role":"assistant","content":"\n\nARCode:
+        Comment.where(ticket_id: Ticket.first.id).last.content\n"},"finish_reason":"stop","index":0}]}
 
         '
-  recorded_at: Mon, 06 Mar 2023 20:42:15 GMT
+  recorded_at: Wed, 08 Mar 2023 14:51:14 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/ar5.yml
+++ b/spec/fixtures/cassettes/ar5.yml
@@ -111,11 +111,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 Mar 2023 19:08:11 GMT
+      - Wed, 08 Mar 2023 14:51:32 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '414'
+      - '505'
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -127,19 +127,20 @@ http_interactions:
       Openai-Organization:
       - user-ri9zw9ahumb1bo9vs73mudbi
       Openai-Processing-Ms:
-      - '1664'
+      - '2550'
       Openai-Version:
       - '2020-10-01'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       X-Request-Id:
-      - b6c993a7474c404744a1929aa373774c
+      - f01e71a93001d8039e56083a100bb0c5
     body:
       encoding: UTF-8
-      string: '{"id":"chatcmpl-6rWxOKx2UiFYFmMCvlWKxftq1UBMK","object":"chat.completion","created":1678216090,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":294,"completion_tokens":43,"total_tokens":337},"choices":[{"message":{"role":"assistant","content":"\n\nARCode:
-        Ticket.where(user_id: 1, status: 0).update_all(user_id: 2)\nARChanges: Ticket.where(user_id:
-        1, status: 0).count\n"},"finish_reason":"stop","index":0}]}
+      string: '{"id":"chatcmpl-6rpQYeRdmBajYzw2GK7gpMMeNkYvi","object":"chat.completion","created":1678287090,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":294,"completion_tokens":65,"total_tokens":359},"choices":[{"message":{"role":"assistant","content":"ARCode:
+        Ticket.where(user_id: User.find_by(name: ''John'').id, status: ''open'').update_all(user_id:
+        User.find_by(name: ''Sally'').id)\nARChanges: Ticket.where(user_id: User.find_by(name:
+        ''John'').id, status: ''open'').count\n"},"finish_reason":"stop","index":0}]}
 
         '
-  recorded_at: Tue, 07 Mar 2023 19:08:11 GMT
+  recorded_at: Wed, 08 Mar 2023 14:51:32 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/ar6.yml
+++ b/spec/fixtures/cassettes/ar6.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":"Given an input question, first
+        create a syntactically correct Rails Active Record code to run,\nthen look
+        at the results of the code and return the answer. Unless the user specifies\nin
+        her question a specific number of examples she wishes to obtain, limit your
+        code\nto at most 5 results.\n\nNever query for all the columns from a specific
+        model, only ask for a the few relevant attributes given the question.\n\nPay
+        attention to use only the attribute names that you can see in the model description.
+        Be careful to not query for attributes that do not exist.\nAlso, pay attention
+        to which attribute is in which model.\n\nUse the following format:\nQuestion:
+        \"Question here\"\nARCode: \"Active Record code to run\"\nARChanges: \"Active
+        Record code to compute the number of records going to change\" - Only add
+        this line if the ARCode on the line before will make data changes\nAnswer:
+        \"Final answer here\"\n\nOnly use the following Active Record models:\n[Comment(id:
+        integer, content: text, user_id: integer, ticket_id: integer, created_at:
+        datetime, updated_at: datetime), Ticket(id: integer, title: string, user_id:
+        integer, status: integer, body: text, created_at: datetime, updated_at: datetime),
+        User(id: integer, name: string, created_at: datetime, updated_at: datetime)]\n\nQuestion:
+        count of comments from Sally?\n"}],"model":"gpt-3.5-turbo","temperature":0.7,"max_tokens":512,"stop":["Answer:"]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <openai_access_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 08 Mar 2023 15:43:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '356'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, must-revalidate
+      Openai-Model:
+      - gpt-3.5-turbo-0301
+      Openai-Organization:
+      - user-ri9zw9ahumb1bo9vs73mudbi
+      Openai-Processing-Ms:
+      - '1163'
+      Openai-Version:
+      - '2020-10-01'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Request-Id:
+      - 5be24bcb1888aada4119f2bf7ee1e143
+    body:
+      encoding: UTF-8
+      string: '{"id":"chatcmpl-6rqFC3ZDCQqkZBmzFoq6tXtG8EgsG","object":"chat.completion","created":1678290230,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":292,"completion_tokens":23,"total_tokens":315},"choices":[{"message":{"role":"assistant","content":"ARCode:
+        Comment.joins(:user).where(users: {name: \"Sally\"}).count\n"},"finish_reason":"stop","index":0}]}
+
+        '
+  recorded_at: Wed, 08 Mar 2023 15:43:51 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/ar7.yml
+++ b/spec/fixtures/cassettes/ar7.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"messages":[{"role":"user","content":"Given an input question, first
+        create a syntactically correct Rails Active Record code to run,\nthen look
+        at the results of the code and return the answer. Unless the user specifies\nin
+        her question a specific number of examples she wishes to obtain, limit your
+        code\nto at most 5 results.\n\nNever query for all the columns from a specific
+        model, only ask for a the few relevant attributes given the question.\n\nPay
+        attention to use only the attribute names that you can see in the model description.
+        Be careful to not query for attributes that do not exist.\nAlso, pay attention
+        to which attribute is in which model.\n\nUse the following format:\nQuestion:
+        \"Question here\"\nARCode: \"Active Record code to run\"\nARChanges: \"Active
+        Record code to compute the number of records going to change\" - Only add
+        this line if the ARCode on the line before will make data changes\nAnswer:
+        \"Final answer here\"\n\nOnly use the following Active Record models:\n[Comment(id:
+        integer, content: text, user_id: integer, ticket_id: integer, created_at:
+        datetime, updated_at: datetime), Ticket(id: integer, title: string, user_id:
+        integer, status: integer, body: text, created_at: datetime, updated_at: datetime),
+        User(id: integer, name: string, created_at: datetime, updated_at: datetime)]\n\nQuestion:
+        tickets asigned to Sally?\n"}],"model":"gpt-3.5-turbo","temperature":0.7,"max_tokens":512,"stop":["Answer:"]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <openai_access_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 08 Mar 2023 16:00:25 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '353'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, must-revalidate
+      Openai-Model:
+      - gpt-3.5-turbo-0301
+      Openai-Organization:
+      - user-ri9zw9ahumb1bo9vs73mudbi
+      Openai-Processing-Ms:
+      - '1017'
+      Openai-Version:
+      - '2020-10-01'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Request-Id:
+      - 46f8b41a70cffce621a294310256d129
+    body:
+      encoding: UTF-8
+      string: '{"id":"chatcmpl-6rqVEegxkAtWM7jFrr3zpHwZCPc7k","object":"chat.completion","created":1678291224,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":292,"completion_tokens":20,"total_tokens":312},"choices":[{"message":{"role":"assistant","content":"ARCode:
+        Ticket.where(user_id: User.find_by(name: \"Sally\").id)\n"},"finish_reason":"stop","index":0}]}
+
+        '
+  recorded_at: Wed, 08 Mar 2023 16:00:25 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/calculator.yml
+++ b/spec/fixtures/cassettes/calculator.yml
@@ -76,14 +76,15 @@ http_interactions:
         but you can''t do any complex calculations that a human could not do in their
         head. You also have an annoying tendency to just make up highly specific,
         but wrong, answers.\nSo we hooked you up to a Ruby 3 kernel, and now you can
-        execute ruby code. If anyone gives you a hard math problem, just use this
-        format and we’ll take care of the rest:\n\nQuestion: ${{Question with hard
-        calculation.}}\n```ruby\n${{Code that prints what you need to know}}\n```\n```output\n${{Output
-        of your code}}\n```\nAnswer: ${{Answer}}\n\nOtherwise, use this simpler format:\n\nQuestion:
-        ${{Question without hard calculation}}\nAnswer: ${{Answer}}\n\nBegin.\n\nQuestion:
-        What is 37593 * 67?\n```ruby\nputs(37593 * 67)\n```\n```output\n2518731\n```\nAnswer:
-        2518731\n\nQuestion: what is 2518731 + 0?\nAnswer: 2518731\n\nQuestion: what
-        is 2.173 to the power of 22.1 then diveded by 27.2? Round to 5 digits.\n"}],"model":"gpt-3.5-turbo","temperature":0.7,"max_tokens":512,"stop":["```output"]}'
+        execute code written in the Ruby programming language. If anyone gives you
+        a hard math problem, just use this format and we’ll take care of the rest:\n\nQuestion:
+        ${{Question with hard calculation.}}\n```ruby\n${{Code that prints what you
+        need to know}}\n```\n```output\n${{Output of your code}}\n```\nAnswer: ${{Answer}}\n\nOtherwise,
+        use this simpler format:\n\nQuestion: ${{Question without hard calculation}}\nAnswer:
+        ${{Answer}}\n\nBegin.\n\nQuestion: What is 37593 * 67?\n```ruby\nputs(37593
+        * 67)\n```\n```output\n2518731\n```\nAnswer: 2518731\n\nQuestion: what is
+        2518731 + 0?\nAnswer: 2518731\n\nQuestion: what is 2.173 to the power of 22.1
+        then diveded by 27.2 to 5 significant digits?\n"}],"model":"gpt-3.5-turbo","temperature":0.7,"max_tokens":512,"stop":["```output"]}'
     headers:
       Content-Type:
       - application/json
@@ -101,11 +102,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 Mar 2023 19:02:49 GMT
+      - Wed, 08 Mar 2023 00:29:32 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '357'
+      - '361'
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -117,18 +118,18 @@ http_interactions:
       Openai-Organization:
       - user-ri9zw9ahumb1bo9vs73mudbi
       Openai-Processing-Ms:
-      - '1146'
+      - '1102'
       Openai-Version:
       - '2020-10-01'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       X-Request-Id:
-      - 6c34e0885cd55f202f24d6e455544bc5
+      - ba8ee74519a53765192f9e1fcee84ddc
     body:
       encoding: UTF-8
-      string: '{"id":"chatcmpl-6rWsC6sHvZ8zCnLspWeyo2avYVLs6","object":"chat.completion","created":1678215768,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":272,"completion_tokens":30,"total_tokens":302},"choices":[{"message":{"role":"assistant","content":"```ruby\nresult
+      string: '{"id":"chatcmpl-6rbyNCJEgFlOsiOYgYGrGcCu3GTyg","object":"chat.completion","created":1678235371,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":276,"completion_tokens":30,"total_tokens":306},"choices":[{"message":{"role":"assistant","content":"\n\n```ruby\nresult
         = (2.173 ** 22.1) / 27.2\nputs result.round(5)\n```\n"},"finish_reason":"stop","index":0}]}
 
         '
-  recorded_at: Tue, 07 Mar 2023 19:02:49 GMT
+  recorded_at: Wed, 08 Mar 2023 00:29:32 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/sql.yml
+++ b/spec/fixtures/cassettes/sql.yml
@@ -79,11 +79,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"messages":[{"role":"user","content":"Given an input question, first
-        create a syntactically correct SQLite3 query to run,\nthen look at the results
-        of the query and return the answer. Unless the user specifies\nin his question
-        a specific number of examples he wishes to obtain, always limit your query\nto
-        at most 5 results using a LIMIT clause. You can order the results by a relevant
-        column\nto return the most interesting examples in the database.\n\nNever
+        create a syntactically correct SQLite3 SQL query to run,\nthen look at the
+        results of the query and return the answer. Unless the user specifies\nin
+        his question a specific number of examples he wishes to obtain, always limit
+        your query\nto at most 5 results using a LIMIT clause. You can order the results
+        by a relevant column\nto return the most interesting examples in the database.\n\nNever
         query for all the columns from a specific table, only ask for a the few relevant
         columns given the question.\n\nPay attention to use only the column names
         that you can see in the schema description. Be careful to not query for columns
@@ -97,7 +97,7 @@ http_interactions:
         NOT NULL,\n updated_at datetime(6) NOT NULL\n);\nCREATE TABLE tickets (\n
         id INTEGER NOT NULL,\n title varchar NULL,\n user_id INTEGER NULL,\n status
         INTEGER NULL,\n body TEXT NULL,\n created_at datetime(6) NOT NULL,\n updated_at
-        datetime(6) NOT NULL\n);\n\nQuestion: how many comments are there from John?\n"}],"model":"gpt-3.5-turbo","temperature":0.6,"max_tokens":512,"stop":["Answer:"]}'
+        datetime(6) NOT NULL\n);\n\nQuestion: how many comments are there from John?\n"}],"model":"gpt-3.5-turbo","temperature":0.7,"max_tokens":512,"stop":["Answer:"]}'
     headers:
       Content-Type:
       - application/json
@@ -115,7 +115,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 Mar 2023 17:46:07 GMT
+      - Wed, 08 Mar 2023 19:17:53 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -131,19 +131,19 @@ http_interactions:
       Openai-Organization:
       - user-ri9zw9ahumb1bo9vs73mudbi
       Openai-Processing-Ms:
-      - '1559'
+      - '1573'
       Openai-Version:
       - '2020-10-01'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       X-Request-Id:
-      - d1aaf4ec505b1762c3955ea2d4807779
+      - fa637a3121a492163b66d8282326a4d4
     body:
       encoding: UTF-8
-      string: '{"id":"chatcmpl-6rVfx9Zilr3C60KU1Iwhosc0ALdze","object":"chat.completion","created":1678211165,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":328,"completion_tokens":33,"total_tokens":361},"choices":[{"message":{"role":"assistant","content":"\n\nSQLQuery:
+      string: '{"id":"chatcmpl-6rtaJkv1F5RHOfX48fxd7CoOw8sgV","object":"chat.completion","created":1678303071,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":329,"completion_tokens":33,"total_tokens":362},"choices":[{"message":{"role":"assistant","content":"\n\nSQLQuery:
         SELECT COUNT(*) FROM comments c JOIN users u ON c.user_id = u.id WHERE u.name
         = ''John''\nSQLResult: 3\n"},"finish_reason":"stop","index":0}]}
 
         '
-  recorded_at: Tue, 07 Mar 2023 17:46:07 GMT
+  recorded_at: Wed, 08 Mar 2023 19:17:53 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/sql2.yml
+++ b/spec/fixtures/cassettes/sql2.yml
@@ -98,7 +98,7 @@ http_interactions:
         id INTEGER NOT NULL,\n title varchar NULL,\n user_id INTEGER NULL,\n status
         INTEGER NULL,\n body TEXT NULL,\n created_at datetime(6) NOT NULL,\n updated_at
         datetime(6) NOT NULL\n);\n\nQuestion: What is the last comment for the first
-        post?\n"}],"model":"gpt-3.5-turbo","temperature":0.6,"max_tokens":512,"stop":["Answer:"]}'
+        post?\n"}],"model":"gpt-3.5-turbo","temperature":0.7,"max_tokens":512,"stop":["Answer:"]}'
     headers:
       Content-Type:
       - application/json
@@ -116,11 +116,11 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 07 Mar 2023 17:46:09 GMT
+      - Wed, 08 Mar 2023 18:47:15 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '509'
+      - '466'
       Connection:
       - keep-alive
       Access-Control-Allow-Origin:
@@ -132,20 +132,19 @@ http_interactions:
       Openai-Organization:
       - user-ri9zw9ahumb1bo9vs73mudbi
       Openai-Processing-Ms:
-      - '2077'
+      - '1979'
       Openai-Version:
       - '2020-10-01'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       X-Request-Id:
-      - 0ecc1e341bdb244088bb5cfa0f5d167c
+      - 89d632d204c10ac93464a4c807f363b4
     body:
       encoding: UTF-8
-      string: '{"id":"chatcmpl-6rVfz9qkrrGsFnMBHeujy7qJOIEc3","object":"chat.completion","created":1678211167,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":330,"completion_tokens":54,"total_tokens":384},"choices":[{"message":{"role":"assistant","content":"\n\nSQLQuery:
+      string: '{"id":"chatcmpl-6rt6fIbNweBG1Up0YdKEIpJTf50iC","object":"chat.completion","created":1678301233,"model":"gpt-3.5-turbo-0301","usage":{"prompt_tokens":330,"completion_tokens":50,"total_tokens":380},"choices":[{"message":{"role":"assistant","content":"\n\nSQLQuery:
         SELECT content, created_at FROM comments WHERE ticket_id = 1 ORDER BY created_at
-        DESC LIMIT 1;\nSQLResult: | content | created_at |\n           |---------|------------|\n           |
-        Lorem   | 2021-10-01 |\n"},"finish_reason":"stop","index":0}]}
+        DESC LIMIT 1;\nSQLResult: \"Great post! Thanks for sharing.|2021-05-13 10:30:00\"\n"},"finish_reason":"stop","index":0}]}
 
         '
-  recorded_at: Tue, 07 Mar 2023 17:46:09 GMT
+  recorded_at: Wed, 08 Mar 2023 18:47:15 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION
Refactored Boxcars to use a Boxcars::Result structure to contain results and context. closes #31 
You can now use the function `conduct` on a Boxcar and get back a Result.

While doing this, took the time to add a list of Tables for the SQL Boxcar. closes #19
You can pass in the tables you want like so: `bcar = Boxcars::SQL.new(tables: ["a_table", "b_table"])` and only those tables will be used for SQL generation.