### PR TITLE
Boxcars::SQL tables and except_tables

### DIFF
--- a/lib/boxcars/boxcar/sql.rb
+++ b/lib/boxcars/boxcar/sql.rb
@@ -41,6 +41,8 @@ module Boxcars
         end
       elsif rtables
         raise ArgumentError, "tables needs to be an array of Strings"
+      else
+        @requested_tables = tables
       end
       @except_models = LOCKED_OUT_TABLES + exceptions.to_a
     end
@@ -55,8 +57,8 @@ module Boxcars
        ");"].join("\n")
     end
 
-    def schema(except_tables: ['ar_internal_metadata'])
-      wanted_tables = tables.to_a - except_tables
+    def schema
+      wanted_tables = @requested_tables - @except_models
       wanted_tables.map(&method(:table_schema)).join("\n")
     end
 


### PR DESCRIPTION
Modified to allow the following specification.

```
boxcar = Boxcars::SQL.new(%w[tickets])
boxcar.run "How many tickets are there?"
```

Also, schema_migrations and ar_internal_metadata will be excluded from the prompt.