### PR TITLE
Draft: added gpt4all

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     boxcars (0.2.6)
       google_search_results (~> 2.2)
-      gpt4all (~> 0.0.2)
+      gpt4all (~> 0.0.4)
       ruby-openai (~> 3.0)
 
 GEM
@@ -70,7 +70,7 @@ GEM
       rainbow (>= 2.2.1)
       rake (>= 10.0)
     google_search_results (2.2.0)
-    gpt4all (0.0.2)
+    gpt4all (0.0.4)
       faraday (~> 2.7)
       os (~> 1.1)
       tty-progressbar (~> 0.18.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     boxcars (0.2.6)
       google_search_results (~> 2.2)
+      gpt4all (~> 0.0.2)
       ruby-openai (~> 3.0)
 
 GEM
@@ -69,6 +70,10 @@ GEM
       rainbow (>= 2.2.1)
       rake (>= 10.0)
     google_search_results (2.2.0)
+    gpt4all (0.0.2)
+      faraday (~> 2.7)
+      os (~> 1.1)
+      tty-progressbar (~> 0.18.2)
     hashdiff (1.0.1)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
@@ -91,6 +96,7 @@ GEM
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
+    os (1.1.4)
     parallel (1.22.1)
     parser (3.2.1.1)
       ast (~> 2.4.1)
@@ -149,10 +155,19 @@ GEM
       faraday (>= 0.17.3, < 3)
     sqlite3 (1.6.2)
       mini_portile2 (~> 2.8.0)
+    sqlite3 (1.6.2-arm64-darwin)
     sqlite3 (1.6.2-x86_64-darwin)
     sqlite3 (1.6.2-x86_64-linux)
+    strings-ansi (0.2.0)
     timers (4.3.5)
     traces (0.9.1)
+    tty-cursor (0.7.1)
+    tty-progressbar (0.18.2)
+      strings-ansi (~> 0.2)
+      tty-cursor (~> 0.7)
+      tty-screen (~> 0.8)
+      unicode-display_width (>= 1.6, < 3.0)
+    tty-screen (0.8.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
@@ -163,6 +178,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
+  arm64-darwin-22
   universal-java-11
   x86_64-darwin-21
   x86_64-darwin-22

--- a/boxcars.gemspec
+++ b/boxcars.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
 
   # runtime dependencies
   spec.add_dependency "google_search_results", "~> 2.2"
+  spec.add_dependency "gpt4all", "~> 0.0.2"
   spec.add_dependency "ruby-openai", "~> 3.0"
 
   # For more information and examples about making a new gem, checkout our

--- a/boxcars.gemspec
+++ b/boxcars.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 
   # runtime dependencies
   spec.add_dependency "google_search_results", "~> 2.2"
-  spec.add_dependency "gpt4all", "~> 0.0.3"
+  spec.add_dependency "gpt4all", "~> 0.0.4"
   spec.add_dependency "ruby-openai", "~> 3.0"
 
   # For more information and examples about making a new gem, checkout our

--- a/boxcars.gemspec
+++ b/boxcars.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 
   # runtime dependencies
   spec.add_dependency "google_search_results", "~> 2.2"
-  spec.add_dependency "gpt4all", "~> 0.0.2"
+  spec.add_dependency "gpt4all", "~> 0.0.3"
   spec.add_dependency "ruby-openai", "~> 3.0"
 
   # For more information and examples about making a new gem, checkout our


### PR DESCRIPTION
changes

TBD 

why?

- instead of using OpenAI's ChatGPT, let users use local `gpt4all` model. the spec for the gem itself is [located here](https://github.com/jaigouk/gpt4all/blob/main/spec/gpt4all_spec.rb)