### PR TITLE
issue_82 typo "Boscar" instead of "Boxcars"

### DIFF
--- a/lib/boxcars/boxcar/active_record.rb
+++ b/lib/boxcars/boxcar/active_record.rb
@@ -161,7 +161,7 @@ module Boxcars
       begin
         return true unless changes&.positive?
       rescue StandardError => e
-        Boscar.error "Error while computing change count: #{e.message}", :red
+        Boxcars.error "Error while computing change count: #{e.message}", :red
       end
 
       Boxcars.debug "#{name}(Pending Changes): #{changes}", :yellow


### PR DESCRIPTION
simple typo causes ActiveRecord read_only: false operations to fail.