### PR TITLE
Support for Sequel SQL connection types

### DIFF
--- a/lib/boxcars/boxcar/sql.rb
+++ b/lib/boxcars/boxcar/sql.rb
@@ -53,7 +53,7 @@ module Boxcars
 
     def table_schema(table)
       ["CREATE TABLE #{table} (",
-       connection&.columns(table)&.map { |c| " #{c.name} #{c.sql_type} #{c.null ? "NULL" : "NOT NULL"}" }&.join(",\n"),
+       connection&.schema(table)&.map { |c| " #{c[0]} #{c[1][:type]} #{c[1][:allow_null] ? "NULL" : "NOT NULL"}" }&.join(",\n"),
        ");"].join("\n")
     end
 


### PR DESCRIPTION
Note: 
This change is not retro-compatible
Closes #22

Of course feel free to not merge or to use as a base if you want to support Sequel but that works for my own project